### PR TITLE
Enable facet filters

### DIFF
--- a/en/theme/material/main.html
+++ b/en/theme/material/main.html
@@ -39,7 +39,7 @@
     indexName: 'cds-ob-docs-wso2',
     inputSelector: '.md-search__input',
     debug: false, // Set debug to true if you want to inspect the dropdown
-    // algoliaOptions: {"facetFilters":["language:en","version:1.0.0"]}
+    algoliaOptions: {"facetFilters":["language:en","version:1.0.0"]}
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
I enable facet filter for the 'cds-wso2-ob-docs' index in Algolia, according to:

> In your [Algolia dashboard](https://www.algolia.com/dashboard/), select your product index in the Indices section. Then go to Configuration > Facets > Attributes for faceting, add the attribute brand, and save. 

[For more info Algolia FAQ here](https://www.algolia.com/doc/integration/salesforce-commerce-cloud-b2c/guides/integrating-algolia-with-sfcc-headless-using-mobify/?client=javascript#add-a-facet-filter)

This PR is to send the relevant files from the front end.