### PR TITLE
Add conf for issue redirection

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report an issue
+    url: https://github.com/wso2/docs-open-banking/issues/new?labels=cds-toolkit
+    about: Click 'Open' to continue. You will be creating the new issue in the 'wso2/docs-open-banking' repo.


### PR DESCRIPTION
This PR will configure the repository such that, when we select the Create New Issue option, we are directed to the WSO2 OB3.0 Repo New Issue Page for creating new issues.

