### PR TITLE
Improvment: Add note about Toolkit merge requirement during Accelerator updates

### DIFF
--- a/en/docs/get-started/set-up-toolkits.md
+++ b/en/docs/get-started/set-up-toolkits.md
@@ -54,6 +54,9 @@ locate the respective root directory of the base products:
     3. Open the `<IS_EXTENSION>/webapps` folder.
     4. Copy the `keymanager-operations.war` file to the `<IS_HOME>/repository/deployment/server/webapps` folder.
 
+!!! note
+    Even if you're only updating the Accelerator, you'll still need to run the Toolkit merge process since the Toolkit includes additional changes on top of the Accelerator. After completing the toolkit setup, remember to re-apply any custom modifications you may have made previously.
+
 ## Set up toolkits
 
 Copy the extracted toolkit directories into the root directories of the respective base products. Use the table to 


### PR DESCRIPTION
## Purpose
Added a note to clarify that the Toolkit merge process must be run even when only updating the Accelerator, as the Toolkit includes additional changes on top of the Accelerator. The note also reminds users to re-apply any custom modifications after completing the toolkit setup.

This addresses potential confusion where users might skip the Toolkit merge step when they're only intending to update the Accelerator.

### Related Issues
https://github.com/wso2-enterprise/wso2-ob-internal/issues/1233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying notes to toolkit setup documentation regarding the Toolkit merge process requirements when updating components.
  * Added guidance on re-applying custom modifications following toolkit setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->